### PR TITLE
Issue 10 - css fixes and website improvements

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -82,7 +82,7 @@ analytics:
 author:
   name             : "Sean Hackett"
   avatar           : "/assets/images/boarding.jpg"
-  bio              : "As a Director of Data Science I try to lay the groudwork for organizational change by connecting data collection, organization, and synthesis. But, I still love getting into the weeds on technical problems where I can continue developing my statistics and programming skills."
+  bio              : "As a Director of Data Science I lay the groudwork for organizational change by connecting data collection, organization, and synthesis. But, I still love getting into the weeds on technical problems where I can continue developing my statistics and programming skills."
   location         : "Brisbane, CA"
   links:
     - label: "GitHub"
@@ -104,7 +104,6 @@ footer:
     - label: "LinkedIn"
       icon: "fab fa-fw fa-linkedin"
       url: "https://www.linkedin.com/in/sean-hackett-53852aaa"
-
 
 # Reading Files
 include:

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -1,5 +1,7 @@
-{% if post.header.teaser %}
-  {% capture teaser %}{{ post.header.teaser }}{% endcapture %}
+{% if post.header.teaser_archive %}
+  {% assign teaser = post.header.teaser_archive %}
+{% elsif post.header.teaser %}
+  {% assign teaser = post.header.teaser %}
 {% else %}
   {% assign teaser = site.teaser %}
 {% endif %}
@@ -12,7 +14,7 @@
 
 <div class="{{ include.type | default: 'list' }}__item">
   <article class="archive__item" itemscope itemtype="https://schema.org/CreativeWork"{% if post.locale %} lang="{{ post.locale }}"{% endif %}>
-    {% if include.type == "grid" and teaser %}
+    {% if teaser and include.type == "grid" %}
       <div class="archive__item-teaser">
         <img src="{{ teaser | relative_url }}" alt="">
       </div>
@@ -25,6 +27,19 @@
       {% endif %}
     </h2>
     {% include page__meta.html type=include.type %}
-    {% if post.excerpt %}<p class="archive__item-excerpt" itemprop="description">{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>{% endif %}
+    {% if post.excerpt %}
+      <div class="archive__item-excerpt" itemprop="description">
+        {% if include.type != "grid" and post.content contains '<!--more-->' %}
+          {{ post.excerpt }}
+        {% else %}
+          {{ post.excerpt | strip_html | truncate: 160 }}
+        {% endif %}
+      </div>
+    {% endif %}
+    {% if teaser and include.type != "grid" and post.header.teaser_archive %}
+      <div class="archive__item-teaser archive__item-teaser--bottom">
+        <img src="{{ teaser | relative_url }}" alt="">
+      </div>
+    {% endif %}
   </article>
 </div>

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -3,7 +3,8 @@
 <script>
   MathJax = {
     tex: {
-      inlineMath: [['$', '$'], ['\\(', '\\)']]
+      inlineMath: [['$', '$'], ['\\(', '\\)']],
+      displayMath: [['$$', '$$'], ['\\[', '\\]']]
     },
     svg: {
       fontCache: 'global'

--- a/_pages/404.html
+++ b/_pages/404.html
@@ -1,14 +1,13 @@
 ---
+layout: page
 title: "Page Not Found"
 excerpt: "Page not found, sorry"
 sitemap: false
 permalink: /404.html
 ---
 
-Sorry, but the page you were trying to view does not exist.
-
+<br><br>
 <div class="page">
   <h1 class="page-title">404: Page not found</h1>
   <p class="lead">Sorry, we've misplaced that URL or it's pointing to something that doesn't exist. <a href="{{ site.baseurl }}/">Head back home</a> to try finding it again.</p>
 </div>
-

--- a/_pages/category-archive.md
+++ b/_pages/category-archive.md
@@ -2,6 +2,7 @@
 title: "Posts by Category"
 layout: categories
 permalink: /categories/
+sitemap: false
 author_profile: true
 header:
   image: /assets/images/banner_06.png

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -5,6 +5,7 @@ classes: wide
 toc: true
 toc_sticky: true
 permalink: /research/
+sitemap: true
 header:
   image: /assets/images/banner_05.png
 ---

--- a/_pages/sitemap.md
+++ b/_pages/sitemap.md
@@ -1,6 +1,6 @@
 ---
-layout: archive
 title: "Sitemap"
+layout: archive
 permalink: /sitemap/
 author_profile: false
 header:
@@ -11,7 +11,9 @@ A list of all the posts and pages found on the site. For you robots out there is
 
 <h2>Pages</h2>
 {% for post in site.pages %}
-  {% include archive-single.html %}
+  {% if post.sitemap == true %}
+    {% include archive-single.html %}
+  {% endif %}
 {% endfor %}
 
 <h2>Posts</h2>
@@ -22,16 +24,16 @@ A list of all the posts and pages found on the site. For you robots out there is
 {% capture written_label %}'None'{% endcapture %}
 
 {% for collection in site.collections %}
-{% unless collection.output == false or collection.label == "posts" %}
-  {% capture label %}{{ collection.label }}{% endcapture %}
-  {% if label != written_label %}
-  <h2>{{ label }}</h2>
-  {% capture written_label %}{{ label }}{% endcapture %}
-  {% endif %}
-{% endunless %}
-{% for post in collection.docs %}
   {% unless collection.output == false or collection.label == "posts" %}
-  {% include archive-single.html %}
+    {% capture label %}{{ collection.label }}{% endcapture %}
+    {% if label != written_label %}
+    <h2>{{ label }}</h2>
+    {% capture written_label %}{{ label }}{% endcapture %}
+    {% endif %}
   {% endunless %}
-{% endfor %}
+  {% for post in collection.docs %}
+    {% unless collection.output == false or collection.label == "posts" %}
+    {% include archive-single.html %}
+    {% endunless %}
+  {% endfor %}
 {% endfor %}

--- a/_pages/tag-archive.md
+++ b/_pages/tag-archive.md
@@ -1,7 +1,8 @@
 ---
 title: "Posts by Tag"
-permalink: /tags/
 layout: tags
+permalink: /tags/
+sitemap: true
 author_profile: true
 header:
   image: /assets/images/banner_03.png

--- a/_pages/year-archive.md
+++ b/_pages/year-archive.md
@@ -1,7 +1,8 @@
 ---
 title: "Posts by Year"
-permalink: /year-archive/
 layout: posts
+permalink: /year-archive/
+sitemap: true
 author_profile: true
 header:
   image: /assets/images/banner_02.png

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -1,34 +1,181 @@
-/* Colors (Replicate Old Site) */
+/* ==========================================================================
+   CUSTOM STYLES - Sean Hackett's Jekyll Site
+   ========================================================================== */
+
+/* ==========================================================================
+   COLOR VARIABLES
+   ========================================================================== */
 $body-background-color: #f0f8ff; /* Light Blue Background */
 $text-color: #333; /* Dark Gray Text */
-$light-contrast: #f5f5f5;
+$light-contrast: #f5f5f5; /* Light Gray/White */
 $link-color: #007bff; /* Default Blue Link */
-/* $light-green: #52C518; */
 $light-green: #228B22; /* Forest Green - classic, readable */
-
 $calico-green: #30BC5B; /* Calico green (not used now) */
 $sidebar-background-color: #f5f5f5; /* Lighter Gray Sidebar */
 
-/* Masthead */
+/* ==========================================================================
+   HEADER & NAVIGATION
+   ========================================================================== */
+
+/* Main masthead styling */
 .masthead {
-    background-color: $light-green;
-    padding: 0.5rem 0; /* Adjust padding as needed */
-    
-    .site-title {
-        color: $light-contrast;
-    }
+  background-color: $light-green;
+  padding: 0.5rem 0;
+  
+  .site-title {
+    color: $light-contrast;
+  }
 }
 
+/* Site navigation */
 #site-nav {
+  background-color: $light-green;
+  
+  img {  
     background-color: $light-green;
-    img {  
-        background-color:$light-green;
-    }
-
-    a {
-        color: $light-contrast;
-    }
+  }
+  
+  a {
+    color: $light-contrast;
+  }
 }
+
+/* Mobile navigation controls (hamburger menu & search toggle) */
+.greedy-nav__toggle,
+.search__toggle {
+  color: $light-contrast !important;
+  
+  &:hover {
+    filter: brightness(0.8); /* Darken on hover */
+  }
+  
+  /* Ensure icons inherit the button color */
+  i {
+    color: inherit !important;
+  }
+}
+
+/* Hamburger menu specific styling */
+.greedy-nav__toggle {
+  .navicon,
+  .navicon::before,
+  .navicon::after {
+    background: $light-contrast !important;
+    transition: all 0.2s ease; /* Smooth transition */
+  }
+  
+  &:hover {
+    .navicon,
+    .navicon::before,
+    .navicon::after {
+      filter: brightness(0.8); /* Darken hamburger lines on hover */
+    }
+  }
+}
+
+/* Mobile dropdown menu styling */
+.hidden-links {
+  background-color: $light-green !important;
+  
+  .masthead__menu-item a {
+    color: $light-contrast !important;
+    
+    &:visited {
+      color: $light-contrast !important;
+    }
+    
+    /* Remove default hover background and let universal link hover handle it */
+    &:hover {
+      background-color: transparent !important;
+    }
+  }
+}
+
+/* Table of contents */
+.nav__title {
+  color: $light-contrast !important; 
+  background-color: $light-green !important;
+}
+
+/* ==========================================================================
+   HERO IMAGE & HEADER
+   ========================================================================== */
+
+.page__hero {
+  margin: 0 !important;
+  padding: 0 !important;
+  overflow: hidden;
+  width: 100%;
+  max-width: 100%;
+  
+  img {
+    width: 100%;
+    height: auto;
+    object-fit: cover;
+  }
+}
+
+/* ==========================================================================
+   FOOTER
+   ========================================================================== */
+
+#footer {
+  background-color: $light-green;
+  padding: 1rem 0;
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+/* ==========================================================================
+   LINKS & BUTTONS
+   ========================================================================== */
+
+/* General link styles with universal hover darkening */
+a {
+  color: $light-green;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  
+  &:hover {
+    filter: brightness(0.8);
+    text-decoration: underline;
+  }
+}
+
+/* Table of contents links */
+.no_toc a {
+  &:link,
+  &:visited {
+    color: $light-green;
+  }
+}
+
+/* Button styling */
+.btn {
+  border-radius: 5px;
+  box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+/* Code folding button */
+.code-fold-btn {
+  background: $light-green;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85em;
+  margin-bottom: 0.5rem;
+  margin-right: 0.5rem;
+  display: block;
+  
+  &:hover {
+    background: darken($light-green, 10%);
+  }
+}
+
+/* ==========================================================================
+   CODE BLOCKS & OUTPUT
+   ========================================================================== */
 
 /* Output code blocks - for code execution results */
 .language-output,
@@ -36,7 +183,6 @@ $sidebar-background-color: #f5f5f5; /* Lighter Gray Sidebar */
   background: $body-background-color !important;
   border-radius: 5px;
   
-  /* Override default code block styling */
   code {
     background: transparent !important;
     color: $text-color !important;
@@ -58,8 +204,7 @@ $sidebar-background-color: #f5f5f5; /* Lighter Gray Sidebar */
   }
 }
 
-/* Clean, consolidated approach for Rmd output blocks */
-/* Only target figure.highlight that contains language-text */
+/* R Markdown output blocks */
 figure.highlight:has(.language-text),
 figure.highlight:has(.language-text) pre {
   background: $body-background-color !important;
@@ -71,88 +216,27 @@ figure.highlight .language-text code {
   color: $text-color !important;
 }
 
-/* Simple Code Folding Button */
-.code-fold-btn {
-  background: $light-green;
-  color: white;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 0.85em;
-  margin-bottom: 0.5rem;
-  margin-right: 0.5rem; /* Add small right margin for any side-by-side cases */
-  display: block; /* Force buttons to stack vertically */
-  
-  &:hover {
-    background: darken($light-green, 10%);
-  }
-}
+/* ==========================================================================
+   LAYOUT & SPACING
+   ========================================================================== */
 
-/* header image (mushroom themed) */
-.page__hero {
-    margin: 0 !important;             /* Override any parent margins */
-    padding: 0 !important;            /* Override any parent padding */
-    overflow: hidden;                 /* Prevent overflow */
-    width: 100%;                      /* Ensure it takes full width */
-    max-width: 100%;                  /* Prevent it from exceeding container width */
-  }
-
-.page__hero img {
-    width: 100%;
-    height: auto;
-    object-fit: cover;
-  }
-
-#footer {
-    background-color: $light-green;
-    padding: 1rem 0; /* Adjust padding as needed */
-    box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1); /* Subtle shadow */
-}
-
-/* Link Styles (Example) */
-a {
-    color: $light-green;
-    text-decoration: none; /* Remove underline */
-    &:hover {
-        text-decoration: underline; /* Add underline on hover */
-    }
-}
-
-.no_toc a {
-    &:link {
-        color: $light-green;
-    }
-    &:visited {
-        color: $light-green;
-    }
-}
-
-/* Rounded Corners and Shadows (Example) */
-.btn {
-    border-radius: 5px; /* Rounded corners */
-    box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.1); /* Subtle shadow */
-}
-
-/* table of contents */
-.nav__title {
-    color: $light-contrast !important; 
-    background-color:$light-green !important;
-}
-
-/* Increase space around content below masthead */
+/* Content spacing */
 .page__content {
-    padding: 1rem;
+  padding: 1rem;
 }
 
-/* MathJax Equations */
+/* ==========================================================================
+   MATHEMATICAL CONTENT
+   ========================================================================== */
+
+/* MathJax equations */
 .mjx-display {
-    display: block;
-    transform: scale(0.7);
-    transform-origin: 50% 50%;
+  display: block;
+  transform: scale(0.7);
+  transform-origin: 50% 50%;
 }
 
 .mjx-inline {
-    display: inline-block;
-    transform: scale(1);
+  display: inline-block;
+  transform: scale(1);
 }


### PR DESCRIPTION
- updates CSS
    - styled hidden icons under the hamburger icon which were white on white and mostly causing a problem on mobile. Closes #10  
    - added fading of links on mouse over
- added full length excerpts to archive lists - they were previously truncated. Switched the behavior depending on whether an archive is a list or a grid (like the read-next summaries on the bottom of posts). Added support for mathjax block equations in excerpts by removing the markdownify conversion. Added the ability to include teaser images for specific posts using the frontmatter.
- cleaned up 404.html and sitemap.md 